### PR TITLE
feat(frontend): add the login page initial design

### DIFF
--- a/frontend/css/login.css
+++ b/frontend/css/login.css
@@ -1,0 +1,67 @@
+body {
+    background-color: #f8f9fa;
+    font-family: 'Tajawal', sans-serif;
+    background-color: #dfe2e3;
+}
+
+.login-container {
+    max-width: 400px;
+    margin: 5rem auto;
+    padding: 2rem;
+    background-color: #fff;
+    border-radius: 0.5rem;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.brand {
+    font-weight: 700;
+    font-size: 2rem;
+    color: #2962ff;
+    text-align: center;
+    margin-bottom: 1rem;
+}
+
+.btn-primary {
+    background: linear-gradient(45deg, #2962ff, #3d5afe);
+    border: none;
+    color: #fff;
+    font-weight: 500;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    transition: all 0.3s ease;
+}
+
+.btn-primary:hover {
+    background: linear-gradient(45deg, #3d5afe, #2962ff);
+    transform: scale(1.02);
+}
+
+.btn-outline {
+    border: 1px solid #3d5afe;
+    color: #3d5afe;
+    font-weight: 500;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    transition: all 0.3s ease;
+}
+
+.btn-outline:hover {
+    background-color: #e9ecef;
+    transform: scale(1.02);
+}
+
+.icon {
+    font-size: 1.5rem;
+}
+
+hr {
+    border-top: 1px solid #e9ecef;
+}
+
+p a:hover {
+    text-decoration: underline;
+}

--- a/frontend/html/login.html
+++ b/frontend/html/login.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Wasl - تسجيل الدخول</title>
+    <!-- Bootstrap CSS -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.rtl.min.css" rel="stylesheet">
+    <!-- Font Awesome -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet">
+    <!-- Custom CSS -->
+    <link href="../css/login.css" rel="stylesheet">
+</head>
+<body>
+
+<div class="container">
+    <div class="login-container">
+        <div class="brand">وصل - تسجيل الدخول</div>
+        <p class="text-center mb-4">يرجى تسجيل الدخول باستخدام حسابك</p>
+
+        <button class="btn btn-primary w-100 mb-3">
+            <i class="fab fa-google icon"></i>
+            تسجيل الدخول باستخدام Google
+        </button>
+
+        <button class="btn btn-outline w-100 mb-3">
+            <i class="fab fa-github icon"></i>
+            تسجيل الدخول باستخدام GitHub
+        </button>
+
+        <hr class="my-4">
+    </div>
+</div>
+
+<!-- Bootstrap JS -->
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
I added a login page that has two OAuth options (Google and github). This will need to be integrated with the API later. 

![image](https://github.com/user-attachments/assets/7d61400e-f96f-43cf-bca5-e810f8813a5a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new login interface with Arabic language support.
	- Enhanced styling for the login page, including modern design elements and responsive interactions.
	- Added buttons for authentication via Google and GitHub with icons.

- **Bug Fixes**
	- Improved visual appeal and user experience of the login interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->