### PR TITLE
Implement user and club services to abstract the schema

### DIFF
--- a/backend/services/clubService.js
+++ b/backend/services/clubService.js
@@ -1,0 +1,75 @@
+const Club = require('../models/club');
+
+// Create new club
+async function createClub(clubData) {
+    const club = new Club(clubData);
+    return await club.save();
+}
+
+// Find club by UUID
+async function findByUUID(uuid) {
+    return await Club.findOne({ uuid });
+}
+
+// Find club by name
+async function findByName(name) {
+    return await Club.findOne({ name });
+}
+
+// Find club by admin
+async function findByAdmin(adminId) {
+    return await Club.find({ clubAdmin: adminId });
+}
+
+// Update club details
+async function updateClub(clubId, updateData) {
+    return await Club.findByIdAndUpdate(
+        clubId,
+        { $set: updateData },
+        { new: true, runValidators: true }
+    );
+}
+
+// Delete club
+async function deleteClub(clubId) {
+    return await Club.findByIdAndDelete(clubId);
+}
+
+// Add event to club
+async function addEvent(clubId, eventId) {
+    // since events are not implemented yet, this function will not do anything
+    return
+}
+
+// Remove event from club
+async function removeEvent(clubId, eventId) {
+    // since events are not implemented yet, this function will not do anything
+    return
+}
+
+// Find clubs by event
+async function findByEvent(eventId) {
+    // since events are not implemented yet, this function will not do anything
+    return
+}
+// Update club admin
+async function updateClubAdmin(clubId, newAdminId) {
+    return await Club.findByIdAndUpdate(
+        clubId,
+        { clubAdmin: newAdminId },
+        { new: true }
+    ).populate('clubAdmin');
+}
+
+module.exports = {
+    createClub,
+    findByUUID,
+    findByName,
+    findByAdmin,
+    updateClub,
+    deleteClub,
+    addEvent,
+    removeEvent,
+    findByEvent,
+    updateClubAdmin
+};

--- a/backend/services/userService.js
+++ b/backend/services/userService.js
@@ -24,16 +24,11 @@ async function findByClubsManaged(clubId) {
     }).populate('clubsManaged');
 }
 
-/*
-* Events are not yet implemented in the application so this function is commented out
 // Find All Users who have joined a specific event
-
 async function findByEventsJoined(eventId) {
-    return await User.find({ 
-        eventsJoined: eventId 
-    }).populate('eventsJoined');
+    // since events are not implemented yet, this function will not do anything
+    return
 }
-*/
 // Find users by role
 async function findByRole(role) {
     return await User.find({ role });

--- a/backend/services/userService.js
+++ b/backend/services/userService.js
@@ -1,0 +1,79 @@
+const User = require('../models/User');
+
+// Find user by UUID
+async function findByUUID(uuid) {
+    return await User.findOne({ uuid });
+}
+
+// Find user by email
+async function findByEmail(email) {
+    return await User.findOne({ email });
+}
+
+// Find all users who have joined a specific club
+async function findByClubsJoined(clubId) {
+    return await User.find({ 
+        clubsJoined: clubId 
+    })
+}
+
+// Find all users who manage a specific club
+async function findByClubsManaged(clubId) {
+    return await User.find({ 
+        clubsManaged: clubId 
+    }).populate('clubsManaged');
+}
+
+/*
+* Events are not yet implemented in the application so this function is commented out
+// Find All Users who have joined a specific event
+
+async function findByEventsJoined(eventId) {
+    return await User.find({ 
+        eventsJoined: eventId 
+    }).populate('eventsJoined');
+}
+*/
+// Find users by role
+async function findByRole(role) {
+    return await User.find({ role });
+}
+
+// Update user profile
+async function updateProfile(userId, updateData) {
+    return await User.findByIdAndUpdate(
+        userId,
+        { $set: updateData },
+        { new: true, runValidators: true }
+    );
+}
+
+// Add user to club
+async function joinClub(userId, clubId) {
+    return await User.findByIdAndUpdate(
+        userId,
+        { $addToSet: { clubsJoined: clubId } },
+        { new: true }
+    );
+}
+
+// Remove user from club
+async function leaveClub(userId, clubId) {
+    return await User.findByIdAndUpdate(
+        userId,
+        { $pull: { clubsJoined: clubId } },
+        { new: true }
+    );
+}
+
+module.exports = {
+    findByUUID,
+    findByEmail,
+    findByClubsJoined,
+    findByClubsManaged,
+    findByEventsJoined,
+    findByRole,
+    updateProfile,
+    joinClub,
+    leaveClub
+};

--- a/backend/services/userService.js
+++ b/backend/services/userService.js
@@ -14,7 +14,7 @@ async function findByEmail(email) {
 async function findByClubsJoined(clubId) {
     return await User.find({ 
         clubsJoined: clubId 
-    })
+    }).populate('clubsJoined');
 }
 
 // Find all users who manage a specific club
@@ -49,7 +49,7 @@ async function joinClub(userId, clubId) {
         userId,
         { $addToSet: { clubsJoined: clubId } },
         { new: true }
-    );
+    ).populate('clubsJoined');
 }
 
 // Remove user from club
@@ -58,7 +58,7 @@ async function leaveClub(userId, clubId) {
         userId,
         { $pull: { clubsJoined: clubId } },
         { new: true }
-    );
+    ).populate('clubsJoined');
 }
 
 module.exports = {


### PR DESCRIPTION
I've created this to simplify queries to the database so that any reused query on a schema is placed in a service file and imported when required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added comprehensive club management service with functionalities for creating, updating, and deleting clubs
	- Introduced user service with advanced user management capabilities
	- Implemented methods for joining and leaving clubs
	- Added user profile update functionality

- **Improvements**
	- Enhanced user and club data retrieval with multiple search methods
	- Supported operations like finding users by role, club, and events

<!-- end of auto-generated comment: release notes by coderabbit.ai -->